### PR TITLE
Log device names to kernel/memcpy records

### DIFF
--- a/tensorflow/core/common_runtime/copy_tensor.cc
+++ b/tensorflow/core/common_runtime/copy_tensor.cc
@@ -238,7 +238,7 @@ void CopyTensor::ViaDMA(StringPiece edge_name, DeviceContext* send_dev_context,
                         const AllocatorAttributes dst_alloc_attr,
                         const Tensor* input, Tensor* output,
                         int dev_to_dev_stream_index, StatusCallback done) {
-  tracing::ScopedAnnotation annotation(edge_name);
+  tracing::ScopedAnnotation annotation(edge_name, StringPiece(), StringPiece(dst->name()));
   VLOG(1) << "Copy " << edge_name;
 
   const DeviceType src_device_type(

--- a/tensorflow/core/common_runtime/copy_tensor.cc
+++ b/tensorflow/core/common_runtime/copy_tensor.cc
@@ -238,7 +238,8 @@ void CopyTensor::ViaDMA(StringPiece edge_name, DeviceContext* send_dev_context,
                         const AllocatorAttributes dst_alloc_attr,
                         const Tensor* input, Tensor* output,
                         int dev_to_dev_stream_index, StatusCallback done) {
-  tracing::ScopedAnnotation annotation(edge_name, StringPiece(), StringPiece(dst->name()));
+  tracing::ScopedAnnotation annotation(edge_name, StringPiece(),
+                                       src->name(), dst->name());
   VLOG(1) << "Copy " << edge_name;
 
   const DeviceType src_device_type(

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -440,7 +440,8 @@ void BaseGPUDevice::Compute(OpKernel* op_kernel, OpKernelContext* context) {
         "Invalid synchronous 'Compute' on GPU for '_Recv' op"));
   } else {
     tracing::ScopedAnnotation annotation(op_kernel->name(),
-                                         op_kernel->type_string());
+                                         op_kernel->type_string(),
+                                         op_kernel->requested_device());
     ComputeHelper(op_kernel, context);
   }
 }

--- a/tensorflow/core/platform/default/device_tracer.cc
+++ b/tensorflow/core/platform/default/device_tracer.cc
@@ -764,7 +764,7 @@ void DeviceTracerImpl::CollectMemcpyRecord(StepStatsCollector *collector,
   auto srcKind = static_cast<CUpti_ActivityMemoryKind>(rec.srcKind);
   auto dstKind = static_cast<CUpti_ActivityMemoryKind>(rec.dstKind);
   const string details = strings::Printf(
-      "[%llu] %s from %s to %s", rec.bytes, name.c_str(),
+      "[%lluB] %s from %s to %s", rec.bytes, name.c_str(),
       src_device.c_str(), dst_device.c_str());
   ns->set_node_name(
       strings::StrCat(name, ":MEMCPY", getMemcpyKindString(copyKind)));

--- a/tensorflow/core/platform/default/device_tracer.cc
+++ b/tensorflow/core/platform/default/device_tracer.cc
@@ -785,11 +785,7 @@ Status DeviceTracerImpl::Collect(StepStatsCollector *collector) {
     CollectKernelRecord(collector, rec);
   }
   for (const auto &rec : memcpy_records_) {
-    // Some memcpy_records are actually kernel_records.
-    // (those that don't have dst_dev)
-    if (dst_dev_correlations_.find(rec.correlation_id) == dst_dev_correlations_.cend()) {
-      CollectKernelRecord(collector, rec);
-    } else {
+    if (dst_dev_correlations_.find(rec.correlation_id) != dst_dev_correlations_.cend()) {
       CollectMemcpyRecord(collector, rec);
     }
   }

--- a/tensorflow/core/platform/tracing.h
+++ b/tensorflow/core/platform/tracing.h
@@ -151,7 +151,7 @@ class TraceCollector {
   virtual ~TraceCollector() {}
   virtual std::unique_ptr<Handle> CreateAnnotationHandle(
       StringPiece name_part1, StringPiece name_part2,
-      StringPiece requested_dev) const = 0;
+      StringPiece src_dev, StringPiece dst_dev) const = 0;
   virtual std::unique_ptr<Handle> CreateActivityHandle(
       StringPiece name_part1, StringPiece name_part2,
       bool is_expensive) const = 0;
@@ -188,12 +188,19 @@ class ScopedAnnotation {
   // label string is only done if tracing is enabled.
   ScopedAnnotation(StringPiece name_part1, StringPiece name_part2,
                    StringPiece requested_dev)
-      : handle_([&] {
-          auto trace_collector = GetTraceCollector();
-          return trace_collector ? trace_collector->CreateAnnotationHandle(
-                                       name_part1, name_part2, requested_dev)
-                                 : nullptr;
-        }()) {}
+      : ScopedAnnotation(name_part1, name_part2, requested_dev, StringPiece()) {}
+
+  // Except for memcpy,
+  //   - src_dev is requested_dev
+  //   - dst_dev is an empty StringPiece()
+  ScopedAnnotation(StringPiece name_part1, StringPiece name_part2,
+                    StringPiece src_dev, StringPiece dst_dev)
+       : handle_([&] {
+           auto trace_collector = GetTraceCollector();
+           return trace_collector ? trace_collector->CreateAnnotationHandle(
+                                        name_part1, name_part2, src_dev, dst_dev)
+                                  : nullptr;
+         }()) {}
 
   bool IsEnabled() const { return static_cast<bool>(handle_); }
 

--- a/tensorflow/core/platform/tracing.h
+++ b/tensorflow/core/platform/tracing.h
@@ -150,7 +150,8 @@ class TraceCollector {
 
   virtual ~TraceCollector() {}
   virtual std::unique_ptr<Handle> CreateAnnotationHandle(
-      StringPiece name_part1, StringPiece name_part2) const = 0;
+      StringPiece name_part1, StringPiece name_part2,
+      StringPiece requested_dev) const = 0;
   virtual std::unique_ptr<Handle> CreateActivityHandle(
       StringPiece name_part1, StringPiece name_part2,
       bool is_expensive) const = 0;
@@ -179,17 +180,18 @@ const TraceCollector* GetTraceCollector();
 class ScopedAnnotation {
  public:
   explicit ScopedAnnotation(StringPiece name)
-      : ScopedAnnotation(name, StringPiece()) {}
+      : ScopedAnnotation(name, StringPiece(), StringPiece("unknown")) {}
 
   // If tracing is enabled, add a name scope of
   // "<name_part1>:<name_part2>".  This can be cheaper than the
   // single-argument constructor because the concatenation of the
   // label string is only done if tracing is enabled.
-  ScopedAnnotation(StringPiece name_part1, StringPiece name_part2)
+  ScopedAnnotation(StringPiece name_part1, StringPiece name_part2,
+                   StringPiece requested_dev)
       : handle_([&] {
           auto trace_collector = GetTraceCollector();
           return trace_collector ? trace_collector->CreateAnnotationHandle(
-                                       name_part1, name_part2)
+                                       name_part1, name_part2, requested_dev)
                                  : nullptr;
         }()) {}
 


### PR DESCRIPTION
**Major changes:**
- Log device name properly (Originally, it was always set to `GPU:0`).
```
/* Before */
device: "/device:GPU:0/memcpy"
...
/* After */
device: "/job:worker/replica:0/task:{worker_id}/device:GPU:{dev_id}/memcpy:all"
...
```

**Minor changes to note:**
- timeline_label format changed
```
/* Before */
timeline_label: "MEMCPYDtoH 8 bytes (Device to Pinned)"
...
/* After */
timeline_label: "[1B] edge_1365_PiecewiseConstant/LessEqual from /job:worker/replica:0/task:0/device:GPU:0 to /job:worker/replica:0/task:0/device:GPU:0"
...
```
**Tests for the changes:**
- Run an tf application and see how `run_metadata` format changed

**Other comments:**
- N/A
