### PR TITLE
Logging of frame_name and iter_num

### DIFF
--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -1613,7 +1613,10 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_nsec) {
     if (stats_collector_ && !tagged_node.is_dead) {
       // track allocations if and only if we are collecting statistics
       params.track_allocations = true;
-      stats = new NodeExecStatsWrapper(node->name());
+      string name = node->name() + "::" + std::to_string(input_iter)
+                    + "::" + input_frame->frame_name;
+      stats = new NodeExecStatsWrapper(name);
+
       nodestats::SetScheduled(stats, scheduled_nsec);
       nodestats::SetAllStart(stats);
     }


### PR DESCRIPTION
**Major changes:**
- frame name and iter_num of while_loops are concatenated at node name for additional logging info.
