### PR TITLE
Unset TraceCollector when finished with kernel execution

### DIFF
--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -2326,6 +2326,7 @@ void ExecutorState::Finish() {
     // the user until the step (and its side-effects) has actually completed.
     status = impl_->params_.device->Sync();
   }
+  tracing::SetTraceCollector(nullptr);
   delete this;
   CHECK(done_cb != nullptr);
   runner([=]() { done_cb(status); });


### PR DESCRIPTION
**Major changes:**
- Unset thread-local pointer to `TraceCollector` to `nullptr` after finished with kernel execution.
  - An RPC request is served (before `Worker::DoRunGraph()` call) by a thread in a Worker's thread pool. https://github.com/snuspl/tensorflow/blob/fbe4cd1af571bfba43914f8d875363e3276ec15a/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc#L200-L205
  - Currently, it is possible that an RPC request references invalid non-null pointer to `TraceCollector` which has been already freed in the previous step.
  - This is because the `Executor` calls `SetTraceCollector()` before kernel execution but doesn't unset it to `nullptr` after finished with execution. Therefore, to check the validity of the pointer, I added a statement that unsets the pointer to null in the clean-up function of `Executor`.
