### PR TITLE
[Bugfix] Fix first call check in ShuffleAndRepeat op

### DIFF
--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -131,9 +131,7 @@ class ShuffleDatasetOpBase::ShuffleDatasetBase : public DatasetBase {
       mutex_lock l(mu_);
       int64 start_micros = ctx->env()->NowMicros();
       int64 num_log_entries = 0;
-      bool first_call = false;
       if (!input_impl_ && epoch_ == 0) {
-        first_call = true;
         TF_RETURN_IF_ERROR(this->dataset()->input_->MakeIterator(
             ctx, this->prefix(), &input_impl_));
       }
@@ -152,10 +150,10 @@ class ShuffleDatasetOpBase::ShuffleDatasetBase : public DatasetBase {
           TF_RETURN_IF_ERROR(input_impl_->GetNext(
               ctx, &input_element, &end_of_input_sequence, index));
           if (!end_of_input_sequence) {
-            first_call = false;
             break;
           }
-          if (first_call && this->dataset()->count_ == -1) {
+          if (ctx->index_manager()->IsFirstCall(this->prefix()) &&
+              this->dataset()->count_ == -1) {
             // If the first call to GetNext() fails because the end
             // of sequence has been reached, we terminate the
             // iteration immediately. (Otherwise, this iterator

--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -131,7 +131,9 @@ class ShuffleDatasetOpBase::ShuffleDatasetBase : public DatasetBase {
       mutex_lock l(mu_);
       int64 start_micros = ctx->env()->NowMicros();
       int64 num_log_entries = 0;
+      bool first_call = false;
       if (!input_impl_ && epoch_ == 0) {
+        first_call = ctx->index_manager()->IsFirstCall(this->prefix())
         TF_RETURN_IF_ERROR(this->dataset()->input_->MakeIterator(
             ctx, this->prefix(), &input_impl_));
       }
@@ -150,10 +152,10 @@ class ShuffleDatasetOpBase::ShuffleDatasetBase : public DatasetBase {
           TF_RETURN_IF_ERROR(input_impl_->GetNext(
               ctx, &input_element, &end_of_input_sequence, index));
           if (!end_of_input_sequence) {
+            first_call = false;
             break;
           }
-          if (ctx->index_manager()->IsFirstCall(this->prefix()) &&
-              this->dataset()->count_ == -1) {
+          if (first_call && this->dataset()->count_ == -1) {
             // If the first call to GetNext() fails because the end
             // of sequence has been reached, we terminate the
             // iteration immediately. (Otherwise, this iterator

--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -133,7 +133,7 @@ class ShuffleDatasetOpBase::ShuffleDatasetBase : public DatasetBase {
       int64 num_log_entries = 0;
       bool first_call = false;
       if (!input_impl_ && epoch_ == 0) {
-        first_call = ctx->index_manager()->IsFirstCall(this->prefix())
+        first_call = ctx->index_manager()->IsFirstCall(this->prefix());
         TF_RETURN_IF_ERROR(this->dataset()->input_->MakeIterator(
             ctx, this->prefix(), &input_impl_));
       }


### PR DESCRIPTION
#### Bug description (How to reporduce)
This bug was reported by jangho.
1. Write a input pipeline containing `ShuffleAndRepeat` op (in Python API, .shuffle() directly followed by .repeat()).
2. Run eparallax and proceed training long enough until you consume one or more dataset file.
3. Scale in or out
4. Then the training fails to proceed.

#### Root cause
In our custom indexed dataset implementation, we should use [`IndexManager::IsFirstCall`](https://github.com/snuspl/tensorflow/blob/82e5d93dcb1fbe59282193f793164fcb4013ca34/tensorflow/core/framework/dataset.cc#L528-L532) to check if a repeat type ops (e.g. [`FiniteRepeat`](https://github.com/snuspl/tensorflow/blob/82e5d93dcb1fbe59282193f793164fcb4013ca34/tensorflow/core/kernels/data/repeat_dataset_op.cc#L135), [`ForeverRepeat`](https://github.com/snuspl/tensorflow/blob/82e5d93dcb1fbe59282193f793164fcb4013ca34/tensorflow/core/kernels/data/repeat_dataset_op.cc#L211), etc.) is called for the first time. But thanks to jangho's bug report, I have found that I neglected the legacy first-call-check in [`ShuffleAndRepeat`](https://github.com/snuspl/tensorflow/blob/e102625efe4de373d722ef39258b1de3102b93dd/tensorflow/core/kernels/data/shuffle_dataset_op.cc#L158-L165).

#### Bug fix
Fixed this to use [`IndexManager::IsFirstCall`](https://github.com/snuspl/tensorflow/blob/82e5d93dcb1fbe59282193f793164fcb4013ca34/tensorflow/core/framework/dataset.cc#L528-L532).

#### Minor optimization
Fixed `IndexManager::IsFirstCall` check in the `ForeverRepeat` op to be called only once at the initialization step, not every call to GetNext.